### PR TITLE
Add optional fileValueGenerator parameter to gumshoe when using struct mode, to populate the struct value for the file

### DIFF
--- a/objects/obj_test/Create_0.gml
+++ b/objects/obj_test/Create_0.gml
@@ -1,5 +1,9 @@
-show_debug_message("struct version:");
-show_debug_message(gumshoe("", "txt", true));
 show_debug_message("array version:");
 show_debug_message(gumshoe("", "txt", false));
+show_debug_message("struct version:");
+show_debug_message(gumshoe("", "txt", true));
+show_debug_message("struct version with value generator:");
+show_debug_message(gumshoe("", "txt", true, , function(directory, file, extension, index) {
+	return directory + file; // the full path to the file
+}));
 show_debug_message("end.");

--- a/objects/obj_test/Draw_64.gml
+++ b/objects/obj_test/Draw_64.gml
@@ -1,0 +1,3 @@
+/// @description 
+
+draw_text(10, 10, "See output log for test cases.");

--- a/objects/obj_test/obj_test.yy
+++ b/objects/obj_test/obj_test.yy
@@ -18,7 +18,8 @@
   "physicsKinematic": false,
   "physicsShapePoints": [],
   "eventList": [
-    {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"parent":{"name":"obj_test","path":"objects/obj_test/obj_test.yy",},"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":64,"eventType":8,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],


### PR DESCRIPTION
Note: I added this for my own use cases, figured I'd send this your way if you think it makes sense for the main repo

Add fileValueGenerator parameter to gumshoe when using struct mode, which is a function that takes the directory, file, extension, and index for the file and returns the value that should be set on the struct for that file
Add example of fileValueGenerator to test object (puts the full path to the file in the struct value)
Add draw event to test object directing user to check the output log for the test case output

* the use of optional params means this bumps the required GMS version - I can undo that if desired
* I also passed nik's added params to the recursive calls in the struct version since GMS was warning me about missing params and it seemed like they should probably go in there