### PR TITLE
Add forceForwardSlash parameter, which makes all generated filepaths use / (forward slash) regardless of platform

### DIFF
--- a/objects/obj_test/Create_0.gml
+++ b/objects/obj_test/Create_0.gml
@@ -1,5 +1,7 @@
 show_debug_message("array version:");
 show_debug_message(gumshoe("", "txt", false));
+show_debug_message("array version with forceForwardSlash: true:");
+show_debug_message(gumshoe("", "txt", false, , , true));
 show_debug_message("struct version:");
 show_debug_message(gumshoe("", "txt", true));
 show_debug_message("struct version with value generator:");

--- a/scripts/gumshoe/gumshoe.gml
+++ b/scripts/gumshoe/gumshoe.gml
@@ -34,7 +34,8 @@ On Microsoft platforms this flag does nothing as the file system is not case sen
 /// @param returnStruct
 /// @param [forceLCNames] Force lowercase names on non-MSFT platforms, see comment(s) above for an explanation.
 /// @param [structValueGenerator] when returnStruct = true, function that generates the value for the file (params: directiory, file, extension, index)
-function gumshoe(_directory, _extension, _return_struct = false, _force_lcnames = true, _generator = undefined)
+/// @param [forceForwardSlash] force all paths to use / as path separator regardless of platform
+function gumshoe(_directory, _extension, _return_struct = false, _force_lcnames = true, _generator = undefined, _force_forward_slash = undefined)
 {
     //Microsoft platforms handle wildcards and patterns slightly different than others (Linux or web based).
     static _is_microsoft =
@@ -63,12 +64,22 @@ function gumshoe(_directory, _extension, _return_struct = false, _force_lcnames 
     {
         throw "Gumshoe: File search is not supported in the JS export module.";
     }
-    
-    //Clean up weirdo directory formats that people might use
-    _directory = string_replace_all(_directory, _inverse_path_separator, _path_separator);
-    if ((_directory != "") && (string_char_at(_directory, string_length(_directory)) != _path_separator))
+	
+	// path separator to use for this call (in case _force_forward_slash is true)
+	var _path_sep = _path_separator;
+	
+	if (_force_forward_slash) {
+		 _directory = string_replace_all(_directory, "\\", "/");
+		 _path_sep = "/";
+	}
+	else {
+        //Clean up weirdo directory formats that people might use
+		_directory = string_replace_all(_directory, _inverse_path_separator, _path_separator);
+	}
+	
+    if ((_directory != "") && (string_char_at(_directory, string_length(_directory)) != _path_sep))
     {
-        _directory += _path_separator;
+        _directory += _path_sep;
     }
     
     //Clean up the extension too
@@ -87,11 +98,11 @@ function gumshoe(_directory, _extension, _return_struct = false, _force_lcnames 
     if (_return_struct)
     {
         global.__gumshoe_count = 0;
-        return __gumshoe_struct(_directory, _extension, _match_all_mask, _path_separator, _generator);
+        return __gumshoe_struct(_directory, _extension, _match_all_mask, _path_sep, _generator);
     }
     else
     {
-        return __gumshoe_array(_directory, _extension, [], _match_all_mask, _path_separator);
+        return __gumshoe_array(_directory, _extension, [], _match_all_mask, _path_sep);
     }
 }
 


### PR DESCRIPTION
Windows platforms *also* support forward slash, so this can make it simpler to write cross-platform compatible file-handling code by always using the same form regardless of platform.

Also added a test case to obj_test to show the result.